### PR TITLE
Support for texture loading on panda3d and pyrender renderers

### DIFF
--- a/pybullet_rendering/examples/panda3d_gui.py
+++ b/pybullet_rendering/examples/panda3d_gui.py
@@ -186,7 +186,10 @@ class MyApp(BaseRenderer, ShowBase):
                     # set texture
                     if shape.material.diffuse_texture > -1:
                         tex = scene_graph.texture(shape.material.diffuse_texture)
-                        model.setTexture(self.loader.loadTexture(tex.filename))
+                        ts = TextureStage('ts')
+                        ts.setMode(TextureStage.MDecal)
+                        node.setTransparency(True)
+                        model.setTexture(ts, self.loader.loadTexture(tex.filename))
 
                 # set relative position
                 pose = shape.pose

--- a/pybullet_rendering/examples/panda3d_gui.py
+++ b/pybullet_rendering/examples/panda3d_gui.py
@@ -186,7 +186,7 @@ class MyApp(BaseRenderer, ShowBase):
                     # set texture
                     if shape.material.diffuse_texture > -1:
                         tex = scene_graph.texture(shape.material.diffuse_texture)
-                        model.setTexture(tex.filename)
+                        model.setTexture(self.loader.loadTexture(tex.filename))
 
                 # set relative position
                 pose = shape.pose

--- a/pybullet_rendering/render/panda3d.py
+++ b/pybullet_rendering/render/panda3d.py
@@ -7,7 +7,7 @@ from panda3d.core import FrameBufferProperties, WindowProperties
 from panda3d.core import ModelNode, NodePath
 from panda3d.core import Camera, MatrixLens, PerspectiveLens
 from panda3d.core import AmbientLight, DirectionalLight, Spotlight
-from panda3d.core import Material, Texture
+from panda3d.core import Material, Texture, TextureStage
 from panda3d.core import RescaleNormalAttrib, AntialiasAttrib
 from panda3d.core import loadPrcFileData
 
@@ -39,8 +39,8 @@ class Renderer(BaseRenderer):
         BaseRenderer.__init__(self)
         self.return_to_bullet = True
         # renderer
-        loadPrcFileData("",
-            f"""
+        loadPrcFileData(
+            "", f"""
             gl-compile-and-execute 1
             gl-use-bindless-texture 1
             prefer-texture-buffer 1
@@ -107,7 +107,10 @@ class Renderer(BaseRenderer):
                     texture_id = pb_shape.material.diffuse_texture
                     if texture_id > -1:
                         texture = scene_graph.texture(texture_id)
-                        shape.set_texture(self._loader.loadTexture(texture.filename))
+                        ts = TextureStage('ts')
+                        ts.setMode(TextureStage.MDecal)
+                        node.setTransparency(True)
+                        shape.set_texture(ts, self._loader.loadTexture(texture.filename))
             node.flatten_light()
             node.reparent_to(self.scene)
             self._node_dict[uid] = node

--- a/pybullet_rendering/render/panda3d.py
+++ b/pybullet_rendering/render/panda3d.py
@@ -107,7 +107,7 @@ class Renderer(BaseRenderer):
                     texture_id = pb_shape.material.diffuse_texture
                     if texture_id > -1:
                         texture = scene_graph.texture(texture_id)
-                        shape.set_texture(texture.filename)
+                        shape.set_texture(self._loader.loadTexture(texture.filename))
             node.flatten_light()
             node.reparent_to(self.scene)
             self._node_dict[uid] = node

--- a/pybullet_rendering/render/pyrender.py
+++ b/pybullet_rendering/render/pyrender.py
@@ -227,16 +227,17 @@ class PbMaterial(pyrender.MetallicRoughnessMaterial):
 
     def __init__(self, pb_material, scene_graph):
         texture_id = pb_material.diffuse_texture
+        kwargs = {}
         if texture_id > -1:
             texture = scene_graph.texture(texture_id)
             img = Image.open(texture.filename)
             tex = pyrender.Texture(source=img, source_channels=img.mode)
+            kwargs = dict(baseColorTexture=tex, alphaMode='BLEND')
 
         super().__init__(baseColorFactor=pb_material.diffuse_color,
-                         baseColorTexture=tex,
-                         alphaMode='BLEND',
                          metallicFactor=0.5,
-                         roughnessFactor=0.5)
+                         roughnessFactor=0.5,
+                         **kwargs)
 
 
 class Loader:


### PR DESCRIPTION
Adding a texture as in the example in issue #8 would crash at [this line](https://github.com/ikalevatykh/pybullet_rendering/blob/7b1a7c7c65f231af2170fea9f96916186b8f0c44/pybullet_rendering/render/panda3d.py#L110) with the following error message

    terminate called after throwing an instance of 'pybind11::error_already_set'
    what():  TypeError: NodePath.set_texture() argument 1 must be panda3d.core.Texture, not str 

This PR fixes the crash by passing the correct argument to the calls to NodePath.setTexture and NodePath.set_texture.