### PR TITLE
Add dependency on Panda3D

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # external requirements
 numpy
 pybullet>=3.0.8
+Panda3D


### PR DESCRIPTION
The `python -m pybullet_rendering.examples.panda3d_gui --multisamples 8` example doesn't work if Panda3D is not installed.